### PR TITLE
Simply return an reversed iterator from `__reversed__`.

### DIFF
--- a/magicmethods.markdown
+++ b/magicmethods.markdown
@@ -491,7 +491,7 @@ For our example, let's look at a list that implements some functional constructs
             return iter(self.values)
 
         def __reversed__(self):
-            return FunctionalList(reversed(self.values))
+            return reversed(self.values)
 
         def append(self, value):
             self.values.append(value)


### PR DESCRIPTION
Currently you're returning an instance of `FunctionalList` with `self.values` set as a `listreverseiterator` object. The problem with this is that user will think that they got an instance of `FunctionalList` back but when they will try to perform any of the operation like `len()`, `__getitem__`, `__setitem__` etc they will end up in errors. So, IMO it's better to return a simple `listreverseiterator` object.
