### PR TITLE
Change "Normal arithmetic operators" from subsection to subsubsection

### DIFF
--- a/magicmethods.tex
+++ b/magicmethods.tex
@@ -131,7 +131,7 @@ Implements behavior for the buil in \code{round()} function. \code{n} is the num
 
 \end{description}
 
-\subsection{Normal arithmetic operators}
+\subsubsection{Normal arithmetic operators}
 
 Now, we cover the typical binary operators (and a function or two): +, -, * and the like. These are, for the most part, pretty self-explanatory.
 


### PR DESCRIPTION
"Normal arithmetic operators" should be a sub-sub section, as in the HTML version.