### PR TITLE
__array__ type conversion op for NumPy array

### DIFF
--- a/magicmethods.markdown
+++ b/magicmethods.markdown
@@ -333,6 +333,9 @@ Python also has an array of magic methods designed to implement behavior for bui
 `__coerce__(self, other)`
 :    Method to implement mixed mode arithmetic. `__coerce__` should return `None` if type conversion is impossible. Otherwise, it should return a pair (2-tuple) of `self` and `other`, manipulated to have the same type.
 
+`__array__(self)`
+:    Implements conversion to a `numpy.ndarray`. Useful for making a numeric class serve as a valid input to NumPy functions. For example, a 3D vector class with members `x, y, z` can implement `def __array__(self): return np.array([self.x, self.y. self.z])`.
+
 
 ##<a id="representations" href="#representations">Representing your Classes</a>##
 

--- a/magicmethods.tex
+++ b/magicmethods.tex
@@ -285,6 +285,8 @@ Implements type conversion to an int when the object is used in a slice expressi
 Called when \code{math.trunc(self)} is called. \code{__trunc__} should return the value of \code{self} truncated to an integral type (usually a long).
 \item[\code{__coerce__(self, other)}]
 Method to implement mixed mode arithmetic. \code{__coerce__} should return \code{None} if type conversion is impossible. Otherwise, it should return a pair (2-tuple) of \code{self} and \code{other}, manipulated to have the same type.
+\item[\code{__array__(self)}]
+Implements conversion to a \code{numpy.ndarray}. Useful for making a numeric class serve as a valid input to NumPy functions. For example, a 3D vector class with members \code{x, y, z} can implement \code{def __array__(self): return np.array([self.x, self.y. self.z])}.
 
 \end{description}
 


### PR DESCRIPTION
This magic method is specific to a third-party library, but it's one of the most popular libraries, and implementing the magic method is very useful for making other numeric code play nicely with NumPy.